### PR TITLE
Hotfix for loading persisted translations when avialable on init

### DIFF
--- a/TranslationManager/Classes/Manager/TranslatableManager.swift
+++ b/TranslationManager/Classes/Manager/TranslatableManager.swift
@@ -209,7 +209,11 @@ public class TranslatableManager<L: LanguageModel, C: LocalizationModel> {
 
         // Start observing state changes
         stateObserver.startObserving()
-        parseFallbackJSONTranslations()
+
+        // Load persisted or fallback translations
+        if (try? translations()) == nil {
+            parseFallbackJSONTranslations()
+        }
 
         switch updateMode {
         case .automatic:


### PR DESCRIPTION
Currently fallback translations were always loaded no matter if
persisted (downloaded) translations are avialable. This resolved in
an issue when the update translations didn't receive any new updates,
then the persisted translations would never be loaded.

This is a hotfix and will need to be refactored.