### PR TITLE
Feature/build libraries for distribution

### DIFF
--- a/LocalizationManager.xcodeproj/project.pbxproj
+++ b/LocalizationManager.xcodeproj/project.pbxproj
@@ -1074,6 +1074,7 @@
 		8C508840230D1D0A00FB80CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1101,6 +1102,7 @@
 		8C508841230D1D0A00FB80CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1172,6 +1174,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -1199,6 +1202,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -1225,6 +1229,7 @@
 		8CBF5813230BCA6C00C60FF7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -1251,6 +1256,7 @@
 		8CBF5814230BCA6C00C60FF7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -1439,6 +1445,7 @@
 		C061C206217889E400449A14 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -1466,6 +1473,7 @@
 		C061C207217889E400449A14 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;

--- a/LocalizationManager.xcodeproj/project.pbxproj
+++ b/LocalizationManager.xcodeproj/project.pbxproj
@@ -1094,7 +1094,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nodes.LocalizationManager-macOS";
 				PRODUCT_NAME = LocalizationManager;
 				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -1122,7 +1122,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nodes.LocalizationManager-macOS";
 				PRODUCT_NAME = LocalizationManager;
 				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1191,7 +1191,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nodes.LocalizationManager-watchOS";
 				PRODUCT_NAME = LocalizationManager;
 				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -1219,7 +1219,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nodes.LocalizationManager-watchOS";
 				PRODUCT_NAME = LocalizationManager;
 				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -1246,7 +1246,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nodes.LocalizationManager-tvOS";
 				PRODUCT_NAME = LocalizationManager;
 				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.2;
@@ -1273,7 +1273,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nodes.LocalizationManager-tvOS";
 				PRODUCT_NAME = LocalizationManager;
 				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.2;
@@ -1463,7 +1463,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.nodes.LocalizationManager;
 				PRODUCT_NAME = LocalizationManager;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1491,7 +1491,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.nodes.LocalizationManager;
 				PRODUCT_NAME = LocalizationManager;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/LocalizationManager/Classes/Manager/LocalizationManager.swift
+++ b/LocalizationManager/Classes/Manager/LocalizationManager.swift
@@ -206,7 +206,7 @@ public class LocalizationManager<Language, Descriptor: LocalizationDescriptor> w
         stateObserver.startObserving()
 
         // Load persisted or fallback translations
-        if (try? translations()) == nil {
+        if (try? localization()) == nil {
             parseFallbackJSONLocalizations()
         }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,7 +11,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Nimble
     - Quick
     - Sourcery
@@ -25,4 +25,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d35a41b3fa3e303afd415e05f5ac04c5dc33ea09
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4


### PR DESCRIPTION
Please check and merge #31 first

Whenever imported (in NStack ios sdk, for example), it would trigger a lot of warnings like this one:

```
⚠️  /Users/vagrant/git/NStackSDK/Classes/NStack Manager/NStack.swift:15:8: module 'TranslationManager' was not compiled with library evolution support; using it means binary compatibility for 'NStackSDK' can't be guaranteed
import TranslationManager
```

This PR fixes that.