### PR TITLE
Fixed wrong name of file

### DIFF
--- a/LocalizationManager/Classes/Manager/LocalizationManager.swift
+++ b/LocalizationManager/Classes/Manager/LocalizationManager.swift
@@ -759,7 +759,7 @@ public class LocalizationManager<Language, Descriptor: LocalizationDescriptor> w
         // Iterate through bundle until we find the localizations file
         for bundle: Bundle in [Bundle(for: localizableModel.self)] + contextRepository.getLocalizationBundles() {
             // Check if bundle contains localizations file, otheriwse continue with next bundle
-            guard let filePath = bundle.path(forResource: "Localization_\(localeId)", ofType: "json") else {
+            guard let filePath = bundle.path(forResource: "Localizations_\(localeId)", ofType: "json") else {
                 continue
             }
 


### PR DESCRIPTION
Got an error because of this. Everywhere else seems to be correct (`Localizations_<locale>`), but here it was `Localization_<locale>`. This fixed my issue.