### PR TITLE
fix: When clearing persisted localizations, set lastUpdatedDate to .distantPast

### DIFF
--- a/LocalizationManager/Classes/Manager/LocalizationManager.swift
+++ b/LocalizationManager/Classes/Manager/LocalizationManager.swift
@@ -381,7 +381,8 @@ public class LocalizationManager<Language, Descriptor: LocalizationDescriptor> w
                 self.handleLocalizationModels(
                     descriptors: configs,
                     acceptHeaderUsed: languageAcceptHeader,
-                    completion: completion)
+                    completion: completion
+                )
 
             case .failure(let error):
                 //error fetching configs
@@ -615,6 +616,7 @@ public class LocalizationManager<Language, Descriptor: LocalizationDescriptor> w
         localizableObjectDictonary.removeAll()
 
         if includingPersisted {
+            lastUpdatedDate = .distantPast
             try deletePersistedLocalizations()
         }
     }

--- a/LocalizationManagerTests/Tests/LocalizationManagerTests.swift
+++ b/LocalizationManagerTests/Tests/LocalizationManagerTests.swift
@@ -272,6 +272,7 @@ class LocalizationManagerTests: XCTestCase {
             try manager.clearLocalizations(includingPersisted: true)
             let newFilePaths = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [])
             XCTAssertTrue(newFilePaths.isEmpty)
+            XCTAssertEqual(manager.lastUpdatedDate, Date.distantPast)
         } catch {
             XCTFail("Failed to get contents of directories")
         }

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,17 @@ let package = Package(
         .target(
             name: "LocalizationManager",
             path: "LocalizationManager/Classes"
+        ),
+        .testTarget(
+            name: "LocalizationManagerTests",
+            dependencies: [.target(name: "LocalizationManager")],
+            path: "LocalizationManagerTests"
+//            exclude: <#T##[String]#>,
+//            sources: <#T##[String]?#>,
+//            cSettings: <#T##[CSetting]?#>,
+//            cxxSettings: <#T##[CXXSetting]?#>,
+//            swiftSettings: <#T##[SwiftSetting]?#>,
+//            linkerSettings: <#T##[LinkerSetting]?#>
         )
     ]
 )


### PR DESCRIPTION
Should fix issue where cached localizations were deleted but never updated due to timestamp being new